### PR TITLE
Fix for compounding

### DIFF
--- a/Sources/ResChatMessageManager/Sources/ResChatMessageManager/UIMessageManager.swift
+++ b/Sources/ResChatMessageManager/Sources/ResChatMessageManager/UIMessageManager.swift
@@ -129,10 +129,15 @@ public extension UIMessageManager {
            }
         }
 
-        // If no existing message matched, append the streaming message
+        // If no existing message was updated, only append if no message with the same ID exists.
+        // A message with the same ID but a higher messagePart means we already have a newer version —
+        // appending the stale one would create a duplicate and regress the displayed content.
         if !didUpdate {
-            currentMessages.append(streamingMessage)
-            currentMessages = Self.sortMessagesByDateAscending(messages: currentMessages)
+            let alreadyExists = currentMessages.contains { $0.id == streamingMessage.id }
+            if !alreadyExists {
+                currentMessages.append(streamingMessage)
+                currentMessages = Self.sortMessagesByDateAscending(messages: currentMessages)
+            }
         }
 
         ProcessLog.shared.log(action: .processStreamingMessage, subActionName: "03. update Bot with Bot/part", messages: currentMessages)

--- a/Sources/ResChatMessageManager/Sources/ResChatMessageManager/UIMessageManager.swift
+++ b/Sources/ResChatMessageManager/Sources/ResChatMessageManager/UIMessageManager.swift
@@ -115,19 +115,26 @@ public extension UIMessageManager {
         ProcessLog.shared.log(action: .processStreamingMessage, subActionName: "02. filter {!$0.isPlaceholder}", messages: currentMessages)
         
         // update Bot with Bot/part
+        var didUpdate = false
         currentMessages = currentMessages.map {
            if  ($0.id == streamingMessage.id
              && $0.messagePart < streamingMessage.messagePart
                 && $0.isBot == true && streamingMessage.isBot == true) {
             var refreshedMessage = $0
                refreshedMessage.update(with: streamingMessage)
-               
+               didUpdate = true
                return refreshedMessage
            } else {
                return $0
            }
         }
-        
+
+        // If no existing message matched, append the streaming message
+        if !didUpdate {
+            currentMessages.append(streamingMessage)
+            currentMessages = Self.sortMessagesByDateAscending(messages: currentMessages)
+        }
+
         ProcessLog.shared.log(action: .processStreamingMessage, subActionName: "03. update Bot with Bot/part", messages: currentMessages)
         
         updateMessages(currentMessages)

--- a/Sources/ResChatProxy/Sources/ResChatProxy/SocketProxy+Sub2Socket.swift
+++ b/Sources/ResChatProxy/Sources/ResChatProxy/SocketProxy+Sub2Socket.swift
@@ -45,11 +45,15 @@ internal extension SocketProxy {
                                     MessageBufferingConfig.myMessagesBufferMessageCount))  // Buffer messages based on time or count
             .sink { [weak self] bufferedMessages in
                 guard let self = self else { return }
-                
-                // Since we're working with a single message, no need to flatten an array of arrays
-                // We map the buffered messages directly to UI-friendly format
-                if let lastBufferedSocketMessage = bufferedMessages.last {
-                    let message = lastBufferedSocketMessage.toMessage()
+
+                // Group by message ID and forward the latest part for each unique message
+                // This ensures we don't drop updates for different messages within the same buffer window
+                var latestByID = [String: Int]()
+                for (index, msg) in bufferedMessages.enumerated() {
+                    latestByID[msg.messageTimestamp] = index
+                }
+                for (_, index) in latestByID {
+                    let message = bufferedMessages[index].toMessage()
                     self._didReceiveStreamingMessagePublisher.send(message)
                 }
             }

--- a/Sources/ResChatProxy/Sources/ResChatProxy/SocketProxy+Sub2Socket.swift
+++ b/Sources/ResChatProxy/Sources/ResChatProxy/SocketProxy+Sub2Socket.swift
@@ -48,11 +48,16 @@ internal extension SocketProxy {
 
                 // Group by message ID and forward the latest part for each unique message
                 // This ensures we don't drop updates for different messages within the same buffer window
+                // We iterate in reverse so the last (most recent) update per ID wins,
+                // then reverse again to preserve original arrival order when forwarding.
                 var latestByID = [String: Int]()
-                for (index, msg) in bufferedMessages.enumerated() {
-                    latestByID[msg.messageTimestamp] = index
+                for index in stride(from: bufferedMessages.count - 1, through: 0, by: -1) {
+                    let id = bufferedMessages[index].messageTimestamp
+                    if latestByID[id] == nil {
+                        latestByID[id] = index
+                    }
                 }
-                for (_, index) in latestByID {
+                for index in latestByID.values.sorted() {
                     let message = bufferedMessages[index].toMessage()
                     self._didReceiveStreamingMessagePublisher.send(message)
                 }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketParsing/ResChatSocket+Merge.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketParsing/ResChatSocket+Merge.swift
@@ -13,8 +13,8 @@ internal extension ResChatSocket {
     
     // remove duplicates, sort by timestamp
     func normalizeHistoryMessages(_ historyMessages: [SocketMessage]) -> [SocketMessage] {
-        let sorted = SocketMessage.sortMessagesByDate(in: historyMessages, ascending: true)
-        let deduped = Array(Set(sorted))
+        let deduped = Array(Set(historyMessages))
+        let sorted = SocketMessage.sortMessagesByDate(in: deduped, ascending: true)
         return sorted
     }
 }

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
@@ -127,10 +127,21 @@ extension ChatViewController {
         guard let manager = self.messageManager else { return }
         
         messagesArrived()
+
+        // Deduplicate by id (timestamp), keeping the last occurrence (most up-to-date)
+        // This prevents NSDiffableDataSourceSnapshot from crashing on duplicate identifiers
+        var seenIDs = Set<String>()
+        var deduplicated = [UIMessage]()
+        for message in manager.uiMessages.reversed() {
+            if seenIDs.insert(message.id).inserted {
+                deduplicated.append(message)
+            }
+        }
+        deduplicated.reverse()
         
         currentSnapshot = UIMessageSnapshot()
         currentSnapshot.appendSections([.main])
-        currentSnapshot.appendItems(manager.uiMessages, toSection: .main)
+        currentSnapshot.appendItems(deduplicated, toSection: .main)
 //        print("updateUI: " + (manager.uiMessages.last?.text ?? "No text"))
         dataSource.apply(currentSnapshot, animatingDifferences: animated)
     }


### PR DESCRIPTION
- hopefully compounding issue fixed. Can't reproduce the issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message buffering, merge/dedup, and UI snapshot inputs for streaming chat, which can affect message ordering and update correctness. Low security impact but moderate risk of regressions in real-time message display.
> 
> **Overview**
> Addresses a *streaming message “compounding”/duplication* issue across the socket→manager→UI pipeline.
> 
> The socket proxy now forwards the latest buffered update **per message id** (instead of only the last buffered message), `UIMessageManager.processStreamingMessage` appends a streaming message when no existing message was updated, and `ChatViewController.updateUI` deduplicates messages by `id` before applying a diffable snapshot to prevent duplicate-identifier crashes.
> 
> Also adjusts history normalization to **dedupe before sorting** in `normalizeHistoryMessages`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9109bf01bbd6a8a85fad40757a06440d8b9497d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->