### PR TITLE
Improvements

### DIFF
--- a/Sources/ResChatAttributedText/Sources/ResChatAttributedText/Markdown2AttributedText.swift
+++ b/Sources/ResChatAttributedText/Sources/ResChatAttributedText/Markdown2AttributedText.swift
@@ -18,7 +18,19 @@ extension UIColor {
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
-        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        // resolvedColor ensures the dynamic color is resolved for the current trait collection,
+        // and converting to sRGB guarantees getRed succeeds (it can fail on grayscale/P3 colors).
+        let resolved = self.resolvedColor(with: UITraitCollection.current)
+        if let srgb = resolved.cgColor.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil) {
+            let components = srgb.components ?? []
+            red = components.count > 0 ? components[0] : 0
+            green = components.count > 1 ? components[1] : 0
+            blue = components.count > 2 ? components[2] : 0
+            alpha = components.count > 3 ? components[3] : 1
+        } else {
+            // Fallback: try getRed directly
+            resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        }
         return String(format: "rgba(%d, %d, %d, %.2f)", Int(red * 255), Int(green * 255), Int(blue * 255), alpha)
     }
 }
@@ -33,7 +45,16 @@ extension NSColor {
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
-        usingColorSpace(.deviceRGB)?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        // Convert to sRGB first to ensure getRed succeeds (fails on catalog/pattern colors)
+        if let rgbColor = usingColorSpace(.sRGB) {
+            rgbColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        } else if let deviceRGB = usingColorSpace(.deviceRGB) {
+            deviceRGB.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        }
+        // If both conversions failed, defaults stay at rgba(0,0,0,0) — use black as fallback
+        if alpha == 0 && red == 0 && green == 0 && blue == 0 {
+            alpha = 1.0 // Ensure text is never transparent
+        }
         return String(format: "rgba(%d, %d, %d, %.2f)", Int(red * 255), Int(green * 255), Int(blue * 255), alpha)
     }
 }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
@@ -32,6 +32,8 @@ open class ResChatSocket {
         _connectionState.eraseToAnyPublisher()
     }
     
+    private var lastStateWasError: Bool = false
+    
     // MARK: SocketConnectionState -
     
     private func sendNewSocketConnectionState(_ newState: SocketConnectionState) {
@@ -48,6 +50,8 @@ open class ResChatSocket {
             
             // Update the last known state
             lastKnownConnectedState = newState
+            // Clear error dedup flag so next error will be emitted
+            lastStateWasError = false
 
             // Send the state to subscribers
             sendNewSocketConnectionState(newState)
@@ -58,11 +62,15 @@ open class ResChatSocket {
     }
     
     func sendUpdateConnectionStateError(_ error: Error?) {
-        if let socketError = error {
-            sendNewSocketConnectionState(.error(socketError))
-        } else {
-            sendNewSocketConnectionState(.error(UnknownStateError.unknownState(message: "Unknown error")))
+        // Deduplicate: don't emit .error again if we're already in error state
+        guard !lastStateWasError else {
+            print("⚠️ [ResChatSocket] Suppressing duplicate .error state")
+            return
         }
+        lastStateWasError = true
+
+        let socketError = error ?? UnknownStateError.unknownState(message: "Unknown error")
+        sendNewSocketConnectionState(.error(socketError))
     }
     
     private var lastKnownLoadingState: SocketConnectionState = .loaded
@@ -185,6 +193,11 @@ open class ResChatSocket {
             .log(false),
             .compress,
             .path(Self.urlPathString),
+            .reconnects(true),
+            .reconnectAttempts(10),
+            .reconnectWait(1),
+            .reconnectWaitMax(30),
+            .randomizationFactor(0.5) 
         ])
         socket = manager.defaultSocket
     }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+HandleEvents.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+HandleEvents.swift
@@ -58,8 +58,25 @@ internal extension ResChatSocket {
     }
     
     func onError(data: [Any]) {
-        let error: Error? = nil // Extract error from data if applicable -
-        ParsedResponseLog.shared.logError(name: "onError", error: error)
+        // Extract meaningful error info from the socket data
+        let errorDescription: String
+        if let firstItem = data.first {
+            if let error = firstItem as? Error {
+                errorDescription = error.localizedDescription
+            } else if let errorString = firstItem as? String {
+                errorDescription = errorString
+            } else if let errorDict = firstItem as? [String: Any] {
+                errorDescription = "Server error: \(errorDict)"
+            } else {
+                errorDescription = "Unknown error type (\(type(of: firstItem))): \(firstItem)"
+            }
+        } else {
+            errorDescription = "Socket error (no data provided)"
+        }
+
+        let error = UnknownStateError.unknownState(message: errorDescription)
+        print("⚠️ [ResChatSocket] onError: \(errorDescription)")
+        ParsedResponseLog.shared.logError(name: "onError: \(errorDescription)", error: error)
         sendUpdateConnectionStateError(error)
     }
 }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
@@ -42,23 +42,25 @@ internal extension ResChatSocket {
             }
         }
 
-        // Fires when Socket.IO attempts a reconnect. The data contains the attempt number.
-        socket.on(clientEvent: .reconnectAttempt) { [weak self] data, ack in
-            let attempt = data.first as? Int ?? -1
-            print("🔄 [ResChatSocket] Reconnect attempt #\(attempt)")
-        }
-
-        // Fires when Socket.IO has exhausted all reconnection attempts.
-        // Transition from .error → .disconnected so the UI stops showing "Reconnecting…"
-        // and shows "No connection" instead.
+        // Fires on each reconnect attempt. The data value counts remaining attempts
+        // (e.g. 10, 9, 8... 1 for 10 configured attempts).
+        // When remaining reaches 1 (last attempt), we wait briefly then check if
+        // the socket is still not connected — if so, transition to .disconnected.
         socket.on(clientEvent: .reconnectAttempt) { [weak self] data, ack in
             guard let self = self else { return }
-            let attempt = data.first as? Int ?? 0
-            // reconnectAttempts is set to 10 in setupSocket()
-            if attempt >= 10 {
-                print("🔴 [ResChatSocket] Max reconnect attempts reached — giving up")
-                Self.socketEventQueue.async {
-                    _ = self.sendNewConnectedState(.disconnected)
+            let remaining = data.first as? Int ?? -1
+            print("🔄 [ResChatSocket] Reconnect attempt (remaining: \(remaining)) | status: \(self.socket.status)")
+
+            if remaining <= 1 {
+                // This is the last attempt. Wait for it to complete before deciding.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+                    guard let self = self else { return }
+                    if self.socket.status != .connected {
+                        print("🔴 [ResChatSocket] Final reconnect attempt failed — transitioning to disconnected")
+                        Self.socketEventQueue.async {
+                            _ = self.sendNewConnectedState(.disconnected)
+                        }
+                    }
                 }
             }
         }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
@@ -6,33 +6,60 @@
 //
 
 import Foundation
+import SocketIO
 
 internal extension ResChatSocket {
-    
+
+    /// Serial queue for all socket event handling.
+    /// Prevents race conditions when connect/disconnect/error events arrive
+    /// near-simultaneously on different threads.
+    static let socketEventQueue = DispatchQueue(label: "com.reschat.socketEvents", qos: .userInitiated)
+
     func setupSocketEvents() {
         setupConnectionSocketEvents()
         setupCustomSocketEvents()
     }
-    
+
     func setupConnectionSocketEvents() {
         socket.on(SocketEventKey.connect.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.connect.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 onConnect(data: data, ack: ack)
             }
         }
 
         socket.on(SocketEventKey.disconnect.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.disconnect.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 onDisconnect(data: data, ack: ack)
             }
         }
-        
+
         socket.on(SocketEventKey.error.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.error.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 onError(data: data, ack: ack)
+            }
+        }
+
+        // Fires when Socket.IO attempts a reconnect. The data contains the attempt number.
+        socket.on(clientEvent: .reconnectAttempt) { [weak self] data, ack in
+            let attempt = data.first as? Int ?? -1
+            print("🔄 [ResChatSocket] Reconnect attempt #\(attempt)")
+        }
+
+        // Fires when Socket.IO has exhausted all reconnection attempts.
+        // Transition from .error → .disconnected so the UI stops showing "Reconnecting…"
+        // and shows "No connection" instead.
+        socket.on(clientEvent: .reconnectAttempt) { [weak self] data, ack in
+            guard let self = self else { return }
+            let attempt = data.first as? Int ?? 0
+            // reconnectAttempts is set to 10 in setupSocket()
+            if attempt >= 10 {
+                print("🔴 [ResChatSocket] Max reconnect attempts reached — giving up")
+                Self.socketEventQueue.async {
+                    _ = self.sendNewConnectedState(.disconnected)
+                }
             }
         }
     }
@@ -40,21 +67,21 @@ internal extension ResChatSocket {
     func setupCustomSocketEvents() {
         socket.on(SocketEventKey.sendHistorySnapshot.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.sendHistorySnapshot.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 handleReceivedConversations(data: data, ack: ack)
             }
         }
-        
+
         socket.on(SocketEventKey.streamMessage.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.streamMessage.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 handleReceivedStreamMessages(data: data, ack: ack)
             }
         }
-        
+
         socket.on(SocketEventKey.updateHistoryItem.rawValue) { data, ack in
             TrafficLog.shared.logOnResponse(named: SocketEventKey.updateHistoryItem.rawValue, data: data)
-            DispatchQueue.global().async { [self] in
+            Self.socketEventQueue.async { [self] in
                 handleReceivedUpdateHistoryItems(data: data, ack: ack)
             }
         }

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
@@ -80,9 +80,25 @@ extension ChatViewController {
         
         UILog.shared.logStreamingMessage(streamingMessage)
         
+        let messageCountBefore = manager.uiMessages.count
         manager.processStreamingMessage(streamingMessage)
-        updateUI(animated: false)
+        let messageCountAfter = manager.uiMessages.count
         
+        let isNewRow = messageCountAfter != messageCountBefore
+        
+        if isNewRow {
+            // A new message row was added (first chunk or new message) —
+            // we need a full snapshot apply so the table view inserts the row.
+            UIView.performWithoutAnimation {
+                updateUI(animated: false)
+                tableView.layoutIfNeeded()
+            }
+        } else {
+            // Existing message updated with new text — update the visible cell
+            // directly to avoid the full snapshot rebuild which causes screen flashing.
+            updateStreamingCellInPlace(with: streamingMessage)
+        }
+
         if currentBotID == nil {
             currentBotID = streamingMessage.id
         } else {
@@ -116,6 +132,36 @@ private extension ChatViewController {
                 let botID = currentBotID else { return }
         guard botMessage.id == botID else { return }
         currentBotID = nil
+    }
+
+    /// Updates the streaming bot cell directly without rebuilding the snapshot.
+    /// This avoids the full diffable data source apply cycle (remove + insert)
+    /// which causes the screen to flash on every streaming chunk.
+    func updateStreamingCellInPlace(with message: UIMessage) {
+        // Find the visible cell that corresponds to this streaming message
+        for cell in tableView.visibleCells {
+            guard let botCell = cell as? ChatBotMessageCell,
+                  let indexPath = tableView.indexPath(for: cell),
+                  let existingMessage = dataSource.itemIdentifier(for: indexPath),
+                  existingMessage.id == message.id else { continue }
+
+            // Reconfigure the cell with the updated message
+            botCell.configure(with: message)
+
+            // Tell the table view to recalculate this cell's height
+            // without reloading (which would cause a flash).
+            UIView.performWithoutAnimation {
+                tableView.beginUpdates()
+                tableView.endUpdates()
+            }
+            return
+        }
+
+        // Cell not visible — fall back to full snapshot apply
+        UIView.performWithoutAnimation {
+            updateUI(animated: false)
+            tableView.layoutIfNeeded()
+        }
     }
 }
 

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
@@ -113,8 +113,8 @@ extension ChatViewController {
         } else {
             updateBotIDWithMessage(streamingMessage)
         }
-        
-        scrollToBottom()
+
+        scrollToBottom(shouldAnimate: false)
     }
     
     func processUpdatedMessage(_ updatedMessage: UIMessage) {

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/ChatProtocolImplementations/ChatViewController+ProxyMessages.swift
@@ -16,17 +16,26 @@ extension ChatViewController {
     func handleConnectionStateChange(_ state: UIConnectionState) {
         switch state {
         case .connected:
-            break
+            hasReceivedConnectionState = true
+            isSocketConnected = true
+            updateDisconnectedIndicator()
         case .disconnected:
-            break
+            isSocketConnected = false
+            // Only show the indicator if we've previously connected.
+            // The initial .disconnected from CurrentValueSubject replay is ignored.
+            updateDisconnectedIndicator(reconnecting: false)
         case .loading:
             // Show a loading indicator while the connection is being established
             showLoadingIndicator()
         case .loaded:
             // Hide any loading indicators and enable full interaction
             hideLoadingIndicator()
+            updateDisconnectedIndicator()
         case .error(_):
-            showSocketErrorAlert()
+            hasReceivedConnectionState = true
+            isSocketConnected = false
+            // Error = socket is trying to reconnect automatically
+            updateDisconnectedIndicator(reconnecting: true)
         case .loadingMore:
             addLoadingMessage()
         case .loadedMore:
@@ -36,7 +45,7 @@ extension ChatViewController {
 }
 
 extension ChatViewController {
-    
+
     func processHistoryMessages(_ receivedMessages: [UIMessage]) {
         guard let manager = self.messageManager else {
             print("Error: message manager is nil")

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/Cells/ChatBotMessageCell+Configure.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/Cells/ChatBotMessageCell+Configure.swift
@@ -33,10 +33,8 @@ extension ChatBotMessageCell {
             stopPlaceholderAnimation()
             updateMessageLabel(with: checkedMessage)
             
-            // If the message is finished and from a specific origin, apply pulse animation
-            if checkedMessage.isFinished && checkedMessage.origin == .updateItem {
-                animatePulse()
-            }
+            // Pulse animation on finished messages removed — it caused visual distraction
+            // and contributed to the perception of UI "jumping" during streaming.
         }
     }
 }

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/Cells/ProvidingTableViewCell.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/Cells/ProvidingTableViewCell.swift
@@ -109,16 +109,4 @@ extension UIView {
     }
 }
 
-extension ProvidingTableViewCell {
-    func animatePulse() {
-        // Perform pulse animation: scale up and back to normal size
-        UIView.animate(withDuration: 0.2, animations: {
-            self.transform = CGAffineTransform(scaleX: 1.1, y: 1.1) // Scale up slightly
-        }) { _ in
-            UIView.animate(withDuration: 0.2, animations: {
-                self.transform = CGAffineTransform.identity // Return to original size
-            })
-        }
-    }
-}
 #endif

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+EnableActions.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+EnableActions.swift
@@ -6,6 +6,7 @@
 //
 #if os(iOS)
 import Foundation
+import UIKit
 
 internal extension ChatViewController {
     
@@ -34,10 +35,54 @@ internal extension ChatViewController {
             messageTextField.isEnabled = enabled
         }
     }
-    
+
     func handleBotTypingState(_ state: BotTypingState) {
         isSendingEnabled = !state.isTyping
-        setUserActionsEnabled(isSendingEnabled)
+        updateSendingEnabled()
+    }
+
+    /// Combines all conditions that determine whether the user can send messages.
+    /// Sending is only allowed when the socket is connected AND the bot is not typing.
+    func updateSendingEnabled() {
+        let canSend = isSocketConnected && isSendingEnabled
+        setUserActionsEnabled(canSend)
+    }
+
+    /// Shows/hides the small "No connection" indicator above the input bar.
+    /// When disconnected and reconnecting, shows a spinner + "Reconnecting…".
+    /// When disconnected and not reconnecting, shows wifi.slash + "No connection".
+    func updateDisconnectedIndicator(reconnecting: Bool = false) {
+        // Don't show the indicator before the first connection attempt has completed.
+        // This prevents flashing "No connection" while the socket is still starting up.
+        guard hasReceivedConnectionState else { return }
+
+        let icon = disconnectedIndicator.viewWithTag(100) as? UIImageView
+        let spinner = disconnectedIndicator.viewWithTag(101) as? UIActivityIndicatorView
+        let label = disconnectedIndicator.viewWithTag(102) as? UILabel
+
+        if isSocketConnected {
+            UIView.animate(withDuration: 0.25) {
+                self.disconnectedIndicator.isHidden = true
+                self.disconnectedIndicator.alpha = 0
+            }
+            spinner?.stopAnimating()
+        } else {
+            if reconnecting {
+                icon?.isHidden = true
+                spinner?.startAnimating()
+                label?.text = "Reconnecting…"
+                label?.textColor = .systemOrange
+            } else {
+                icon?.isHidden = false
+                spinner?.stopAnimating()
+                label?.text = "No connection"
+                label?.textColor = .systemRed
+            }
+            UIView.animate(withDuration: 0.25) {
+                self.disconnectedIndicator.isHidden = false
+                self.disconnectedIndicator.alpha = 1
+            }
+        }
     }
 }
 #endif

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+EnableActions.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+EnableActions.swift
@@ -61,10 +61,11 @@ internal extension ChatViewController {
         let label = disconnectedIndicator.viewWithTag(102) as? UILabel
 
         if isSocketConnected {
-            UIView.animate(withDuration: 0.25) {
-                self.disconnectedIndicator.isHidden = true
+            UIView.animate(withDuration: 0.25, animations: {
                 self.disconnectedIndicator.alpha = 0
-            }
+            }, completion: { _ in
+                self.disconnectedIndicator.isHidden = true
+            })
             spinner?.stopAnimating()
         } else {
             if reconnecting {

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+TextViewDelegate.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController+TextViewDelegate.swift
@@ -30,6 +30,10 @@ extension ChatViewController: UITextViewDelegate {
     
     public func textViewDidEndEditing(_ textView: UITextView) {
         if let text = textView.text, !text.isEmpty, text != placeholderText {
+            guard isSocketConnected else {
+                print("⚠️ [ChatViewController] textView send blocked — socket not connected")
+                return
+            }
             sendUserMessage(text)
             textView.clearPlaceholder()
         } else {

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
@@ -655,14 +655,14 @@ public extension ChatViewController {
 
 extension ChatViewController {
     
-    func scrollToBottom() {
+    func scrollToBottom(shouldAnimate: Bool = true) {
         let numberOfRows = tableView.numberOfRows(inSection: 0)
         
         // Ensure there is at least one row to scroll to
         guard numberOfRows > 0 else { return }
         
         let indexPath = IndexPath(row: numberOfRows - 1, section: 0)
-        tableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+        tableView.scrollToRow(at: indexPath, at: .bottom, animated: shouldAnimate)
     }
     
     func scrollToTop() {

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
@@ -115,11 +115,29 @@ open class ChatViewController: PlatformViewController {
         didSet {
             if oldValue != isSendingEnabled {
                 print("`isSendingEnabled` Value changed from \(oldValue) to \(isSendingEnabled)")
-                setUserActionsEnabled(isSendingEnabled)
+                updateSendingEnabled()
             }
         }
     }
     
+    /// Tracks whether the socket is currently connected.
+    /// When false, sending messages is disabled.
+    internal var isSocketConnected: Bool = false {
+        didSet {
+            guard oldValue != isSocketConnected else { return }
+            print("🔌 [ChatViewController] isSocketConnected changed: \(oldValue) → \(isSocketConnected)")
+            updateSendingEnabled()
+            // Don't call updateDisconnectedIndicator here — it's called explicitly
+            // from handleConnectionStateChange with the correct reconnecting flag.
+        }
+    }
+
+    /// Whether the socket has ever received a connection state change.
+    /// The disconnected indicator is suppressed until this is true,
+    /// so it doesn't flash "No connection" before the first attempt completes.
+    internal var hasReceivedConnectionState: Bool = false
+
+
     internal var currentBotID: String? = nil {
         didSet {
             // Check for transition from nil to String or String to nil
@@ -251,6 +269,57 @@ open class ChatViewController: PlatformViewController {
         return view
     }()
         
+    /// Small icon shown over the input area when the socket is disconnected.
+    internal lazy var disconnectedIndicator: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.isHidden = true // hidden by default (assumes connected)
+        container.isUserInteractionEnabled = false
+
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: "wifi.slash")
+        imageView.tintColor = .systemRed
+        imageView.contentMode = .scaleAspectFit
+        imageView.tag = 100 // tag to find it later
+
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.color = .systemOrange
+        spinner.hidesWhenStopped = true
+        spinner.tag = 101 // tag to find it later
+        spinner.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "No connection"
+        label.font = .systemFont(ofSize: 11, weight: .medium)
+        label.textColor = .systemRed
+        label.tag = 102 // tag to find it later
+
+        container.addSubview(imageView)
+        container.addSubview(spinner)
+        container.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 14),
+            imageView.heightAnchor.constraint(equalToConstant: 14),
+
+            spinner.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            spinner.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            spinner.widthAnchor.constraint(equalToConstant: 14),
+            spinner.heightAnchor.constraint(equalToConstant: 14),
+
+            label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 4),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        return container
+    }()
+
     private lazy var messageInputContainerView: UIView = {
         let aView = UIView()
         aView.translatesAutoresizingMaskIntoConstraints = false
@@ -338,6 +407,10 @@ open class ChatViewController: PlatformViewController {
         setupMessageInputContainer()
         setupKeyboard()
         setupLoadingView()
+
+        // Disable sending on launch until socket connects, but don't show
+        // the disconnected indicator yet — give the socket a chance to connect first.
+        updateSendingEnabled()
         
         setupSpeechRecognizer()
         
@@ -376,16 +449,24 @@ open class ChatViewController: PlatformViewController {
     
     private func setupMessageInputContainer() {
         view.addSubview(messageInputContainerView)
-        
+
         messageInputContainerBottomConstraint = messageInputContainerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        
+
         NSLayoutConstraint.activate([
             messageInputContainerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             messageInputContainerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             messageInputContainerBottomConstraint!,
             messageInputContainerView.heightAnchor.constraint(equalToConstant: LayoutConstants.messageInputContainerViewHeight)  // Explicit height
         ])
-        
+
+        // Add disconnected indicator above the input bar
+        view.addSubview(disconnectedIndicator)
+        NSLayoutConstraint.activate([
+            disconnectedIndicator.bottomAnchor.constraint(equalTo: messageInputContainerView.topAnchor, constant: -4),
+            disconnectedIndicator.centerXAnchor.constraint(equalTo: messageInputContainerView.centerXAnchor),
+            disconnectedIndicator.heightAnchor.constraint(equalToConstant: 18),
+        ])
+
         setupNoKeyboardTableViewContentInset()
     }
     
@@ -607,6 +688,11 @@ internal extension ChatViewController {
 internal extension ChatViewController {
     
     @objc func sendMessage() {
+        // Block sending if socket is not connected
+        guard isSocketConnected else {
+            print("⚠️ [ChatViewController] sendMessage blocked — socket not connected")
+            return
+        }
         if usesTextView {
             sendTextViewMessage()
         } else {

--- a/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
+++ b/Sources/ResChatUIKit/Sources/ResChatUIKit/UI/ChatViewController.swift
@@ -76,7 +76,7 @@ open class ChatViewController: PlatformViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 100
+        tableView.estimatedRowHeight = 300
         tableView.delegate = self
         tableView.backgroundColor = colorProvider.backgroundColor
         AttributedTextCache.shared.clearCache()


### PR DESCRIPTION
- potential fix for white colored text
- improvement reloading of chat
- ui improvements
- reconnection fix
- error report enhanced
- added serial queue for sockets 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches socket connection/reconnect state handling and chat UI update paths; regressions could affect connection indicators, message sending enablement, or event ordering under disconnect/reconnect races.
> 
> **Overview**
> **Improves rendering correctness:** updates `toCSSColor()` for `UIColor`/`NSColor` to resolve dynamic colors and convert to RGB/sRGB first, reducing failures that could yield incorrect/transparent text.
> 
> **Hardens socket reconnection + error reporting:** adds explicit Socket.IO reconnect configuration, serializes all socket event handling on a dedicated queue, extracts richer error details from `onError`, and deduplicates repeated `.error` state emissions (resetting on connect/disconnect).
> 
> **Refines chat UX during disconnects and streaming:** disables sending unless the socket is connected, adds a small disconnect/reconnecting indicator above the input bar, increases table `estimatedRowHeight`, avoids full diffable snapshot applies on every streaming chunk by updating the visible bot cell in place, and removes the finished-message pulse animation to reduce perceived UI jumping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ed04eb924bef9926b019edfea1bd094a33531b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->