### PR TITLE
Minor fix

### DIFF
--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
@@ -69,6 +69,12 @@ open class ResChatSocket {
         }
         lastStateWasError = true
 
+        // Reset lastKnownConnectedState so that when Socket.IO reconnects,
+        // the next .connected is recognized as a state change (not suppressed).
+        // Without this, the dedup check in sendNewConnectedState sees
+        // .connected == .connected and swallows the reconnection event.
+        lastKnownConnectedState = .disconnected
+
         let socketError = error ?? UnknownStateError.unknownState(message: "Unknown error")
         sendNewSocketConnectionState(.error(socketError))
     }
@@ -194,7 +200,7 @@ open class ResChatSocket {
             .compress,
             .path(Self.urlPathString),
             .reconnects(true),
-            .reconnectAttempts(10),
+            .reconnectAttempts(-1),   // Unlimited — never give up reconnecting
             .reconnectWait(1),
             .reconnectWaitMax(30),
             .randomizationFactor(0.5) 

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/ResChatSocket.swift
@@ -61,21 +61,29 @@ open class ResChatSocket {
         return false
     }
     
-    func sendUpdateConnectionStateError(_ error: Error?) {
-        // Deduplicate: don't emit .error again if we're already in error state
+    /// Reports a connection-level error (socket disconnect, timeout, server rejection).
+    /// Resets `lastKnownConnectedState` so a subsequent reconnect `.connected` won't be suppressed.
+    func sendSocketConnectionError(_ error: Error?) {
         guard !lastStateWasError else {
             print("⚠️ [ResChatSocket] Suppressing duplicate .error state")
             return
         }
         lastStateWasError = true
 
-        // Reset lastKnownConnectedState so that when Socket.IO reconnects,
-        // the next .connected is recognized as a state change (not suppressed).
-        // Without this, the dedup check in sendNewConnectedState sees
-        // .connected == .connected and swallows the reconnection event.
+        // Reset so the next .connected is recognized as a state change.
         lastKnownConnectedState = .disconnected
 
         let socketError = error ?? UnknownStateError.unknownState(message: "Unknown error")
+        sendNewSocketConnectionState(.error(socketError))
+    }
+
+    /// Reports a data-level error (parsing failure) while the socket remains connected.
+    /// Does NOT reset `lastKnownConnectedState` because the connection is still alive.
+    func sendDataError(_ error: Error?) {
+        let socketError = error ?? UnknownStateError.unknownState(message: "Unknown data error")
+        print("⚠️ [ResChatSocket] Data error (socket still connected): \(socketError.localizedDescription)")
+        // Emit .error so the UI can show a message if needed, but don't
+        // touch lastKnownConnectedState — the socket is still connected.
         sendNewSocketConnectionState(.error(socketError))
     }
     

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+HandleEvents.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+HandleEvents.swift
@@ -77,7 +77,7 @@ internal extension ResChatSocket {
         let error = UnknownStateError.unknownState(message: errorDescription)
         print("⚠️ [ResChatSocket] onError: \(errorDescription)")
         ParsedResponseLog.shared.logError(name: "onError: \(errorDescription)", error: error)
-        sendUpdateConnectionStateError(error)
+        sendSocketConnectionError(error)
     }
 }
 
@@ -118,11 +118,11 @@ extension ResChatSocket {
         } catch let error as ParsingDataError {
             print("Parsing Error: \(error.localizedDescription)")
             ParsedResponseLog.shared.logReceivedConversationsError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         } catch {
             print("An unexpected error occurred: \(error)")
             ParsedResponseLog.shared.logReceivedConversationsError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         }
     }
     
@@ -138,11 +138,11 @@ extension ResChatSocket {
         } catch let error as ParsingDataError {
             print("Parsing Error: \(error.localizedDescription)")
             ParsedResponseLog.shared.logReceivedStreamMessagesError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         } catch {
             print("An unexpected error occurred: \(error)")
             ParsedResponseLog.shared.logReceivedStreamMessagesError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         }
     }
     
@@ -159,11 +159,11 @@ extension ResChatSocket {
         } catch let error as ParsingDataError {
             print("Parsing Error: \(error.localizedDescription)")
             ParsedResponseLog.shared.logReceivedUpdateHistoryItemsError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         } catch {
             print("An unexpected error occurred: \(error)")
             ParsedResponseLog.shared.logReceivedUpdateHistoryItemsError(error)
-            sendUpdateConnectionStateError(error)
+            sendDataError(error)
         }
         
     }

--- a/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
+++ b/Sources/ResChatSocket/Sources/ResChatSocket/Socket/SocketEvents/ResChatSocket+SetupEvents.swift
@@ -42,27 +42,12 @@ internal extension ResChatSocket {
             }
         }
 
-        // Fires on each reconnect attempt. The data value counts remaining attempts
-        // (e.g. 10, 9, 8... 1 for 10 configured attempts).
-        // When remaining reaches 1 (last attempt), we wait briefly then check if
-        // the socket is still not connected — if so, transition to .disconnected.
+        // Fires on each reconnect attempt. With unlimited retries (-1), Socket.IO
+        // will keep trying with exponential backoff (1s → 30s) until the server is reachable.
         socket.on(clientEvent: .reconnectAttempt) { [weak self] data, ack in
             guard let self = self else { return }
-            let remaining = data.first as? Int ?? -1
-            print("🔄 [ResChatSocket] Reconnect attempt (remaining: \(remaining)) | status: \(self.socket.status)")
-
-            if remaining <= 1 {
-                // This is the last attempt. Wait for it to complete before deciding.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
-                    guard let self = self else { return }
-                    if self.socket.status != .connected {
-                        print("🔴 [ResChatSocket] Final reconnect attempt failed — transitioning to disconnected")
-                        Self.socketEventQueue.async {
-                            _ = self.sendNewConnectedState(.disconnected)
-                        }
-                    }
-                }
-            }
+            let attempt = data.first as? Int ?? -1
+            print("🔄 [ResChatSocket] Reconnect attempt \(attempt) | status: \(self.socket.status)")
         }
     }
     


### PR DESCRIPTION
- minor fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Socket.IO reconnection behavior to retry indefinitely and adjusts connection-state deduping, which can affect client networking behavior and downstream subscribers’ state handling.
> 
> **Overview**
> Fixes a reconnection edge case where, after emitting `.error`, a subsequent Socket.IO reconnect could have its `.connected` state suppressed due to state deduping; the error handler now resets `lastKnownConnectedState` so reconnections are surfaced.
> 
> Updates Socket.IO configuration to use unlimited reconnect attempts (`.reconnectAttempts(-1)`) and simplifies the `.reconnectAttempt` handler by removing “final attempt failed → force `.disconnected`” logic, relying on backoff retries instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd3286344bbe2d705f0c90736738c0efc6b78710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->